### PR TITLE
Updating to Steel 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,9 +100,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "anymap3"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5dfbc6d8d2675589ccbe4d0fd61df2419075625f8c1a62325e718e2b0049f9"
 
 [[package]]
 name = "arc-swap"
@@ -188,15 +194,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitmaps"
@@ -231,12 +231,6 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -342,15 +336,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,33 +422,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crossterm"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
-dependencies = [
- "bitflags 2.9.3",
- "crossterm_winapi",
- "derive_more",
- "document-features",
- "mio",
- "parking_lot",
- "rustix",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,27 +466,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,12 +476,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.11"
+name = "displaydoc"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
- "litrs",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -587,12 +526,11 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6215aee357f8c7c989ebb4b8466ca4d7dc93b3957039f2fc3ea2ade8ea5f279"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set",
- "derivative",
  "regex-automata",
  "regex-syntax",
 ]
@@ -620,21 +558,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "frep-core"
-version = "0.1.3"
+name = "foldhash"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db81e5b545be45b20e0e4587e248c11b7bf4b2add31430a2d47cf243449c9ae"
-dependencies = [
- "anyhow",
- "content_inspector",
- "crossterm",
- "fancy-regex",
- "ignore",
- "log",
- "regex",
- "simple-log",
- "tempfile",
-]
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures-core"
@@ -685,15 +612,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generational-arena"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +628,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "generic_singleton"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6e923c8e978e57cf63e2e200ca967d1d20f0ea2662b28f6d4e11c44aa6ab16"
+dependencies = [
+ "anymap3",
+ "parking_lot",
 ]
 
 [[package]]
@@ -775,15 +703,29 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "httparse"
@@ -822,6 +764,94 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_casemap"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "070f98b5b82798fcb93654bf96ed9f40064fc44c86f51a09ea711092cd5cc5be"
+dependencies = [
+ "icu_casemap_data",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties",
+ "icu_provider",
+ "potential_utf",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_casemap_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "846b0857ca091204be3c874bc93daaf89d4777e8d2d20b0d3ffe8f671d98014b"
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "serde",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "serde",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ignore"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,10 +884,11 @@ dependencies = [
 
 [[package]]
 name = "im-lists"
-version = "0.9.1"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b971d2652e5700514cc92ca020dba64c790352af0ff2b9acb7514868a32d6aa"
+checksum = "82158d5d59eff663dbb9d89295eacac296f58bc0473331cea2f45d9d270c5540"
 dependencies = [
+ "generic_singleton",
  "smallvec",
 ]
 
@@ -888,12 +919,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -926,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -959,10 +990,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
-name = "litrs"
-version = "0.4.2"
+name = "litemap"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1012,9 +1043,18 @@ dependencies = [
  "serde-value",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.69",
  "thread-id",
  "winapi",
+]
+
+[[package]]
+name = "lru"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1044,14 +1084,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1112,7 +1151,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1135,6 +1174,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]
@@ -1191,7 +1241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
 dependencies = [
  "base64",
- "indexmap 2.11.0",
+ "indexmap 2.14.0",
  "quick-xml",
  "serde",
  "time",
@@ -1209,6 +1259,17 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "serde_core",
+ "writeable",
+ "zerovec",
 ]
 
 [[package]]
@@ -1256,20 +1317,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "quickscope"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d47bcfc3e13850589cf9338a02b6dfb5aebb3748a0f93a392e8df91d6193b6b"
-dependencies = [
- "indexmap 1.9.3",
- "smallvec",
-]
-
-[[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1289,6 +1340,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -1328,6 +1380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+ "serde",
 ]
 
 [[package]]
@@ -1350,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1374,14 +1427,14 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1391,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1402,9 +1455,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "repr_offset"
@@ -1414,6 +1467,12 @@ checksum = "fb1070755bd29dffc19d0971cab794e607839ba2ef4b69a9e6fbc8733c1b72ea"
 dependencies = [
  "tstr",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -1430,7 +1489,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1460,21 +1519,30 @@ dependencies = [
 
 [[package]]
 name = "scooter-core"
-version = "0.1.6"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c71694605ca7f73cf96705e7e52f4ba5ca5469b197c98c4d695b8a9f8f210cd"
+checksum = "8475b7964841ea90f7763ffa5161910219931a6914dcc7ca6c74ec3e4bbfdafd"
 dependencies = [
  "anyhow",
- "bitflags 2.9.3",
- "frep-core",
+ "bitflags",
+ "content_inspector",
+ "etcetera",
+ "fancy-regex",
  "ignore",
  "log",
+ "lru",
  "rayon",
+ "regex",
+ "serde",
  "similar",
+ "simple-log",
  "steel-core",
- "steel-derive 0.6.0",
- "syntect",
+ "steel-derive",
+ "tempfile",
+ "termini",
  "tokio",
+ "toml",
+ "two-face",
  "unicode-width 0.2.2",
 ]
 
@@ -1483,15 +1551,15 @@ name = "scooter-hx-engine"
 version = "0.1.4"
 dependencies = [
  "abi_stable",
+ "anyhow",
  "crossbeam",
  "etcetera",
- "frep-core",
  "ignore",
  "log",
  "scooter-core",
  "simple-log",
  "steel-core",
- "steel-derive 0.8.2",
+ "steel-derive",
  "tempfile",
  "tokio",
  "unicode-width 0.2.2",
@@ -1525,7 +1593,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float",
+ "ordered-float 2.10.1",
  "serde",
 ]
 
@@ -1562,12 +1630,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -1575,31 +1652,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_vector"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aacfea9afcf271e69d700140dc2a3e2ff44b1092dd0de71fdd4e5c26672a2"
+dependencies = [
+ "allocator-api2",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
 
 [[package]]
 name = "signal-hook-registry"
@@ -1612,9 +1677,12 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.7.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "simple-log"
@@ -1626,7 +1694,7 @@ dependencies = [
  "log4rs",
  "once_cell",
  "serde",
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -1653,13 +1721,19 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1669,9 +1743,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steel-core"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fcd4a04c6b2fc5f695ad37b379ad0e4245a9a12dcd742fe4fe1ad15ddd6546"
+checksum = "b4acadc255e0d56fe71c09c605ebde51e6009b02d86ae610386f26437c4f91f8"
 dependencies = [
  "abi_stable",
  "arc-swap",
@@ -1682,18 +1756,20 @@ dependencies = [
  "codespan-reporting",
  "compact_str",
  "crossbeam-channel",
+ "crossbeam-queue",
  "crossbeam-utils",
  "env_home",
  "futures-executor",
  "futures-task",
  "futures-util",
- "fxhash",
  "getrandom 0.3.3",
  "glob",
  "httparse",
+ "icu_casemap",
  "im",
  "im-lists",
  "im-rc",
+ "js-sys",
  "lasso",
  "log",
  "md-5",
@@ -1704,29 +1780,21 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "polling",
- "quickscope",
  "rand 0.9.2",
+ "rustc-hash",
  "serde",
  "serde_json",
+ "shared_vector",
  "smallvec",
- "steel-derive 0.6.0",
+ "steel-derive",
  "steel-gen",
  "steel-parser",
+ "steel-quickscope",
  "strsim",
+ "thin-vec",
  "weak-table",
  "which",
  "xdg",
-]
-
-[[package]]
-name = "steel-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab7d1c6e3ee7b3ba6a4187b545d7dc1fa6e4929f0721a8798cfc3b8c7ed2b23"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -1742,9 +1810,9 @@ dependencies = [
 
 [[package]]
 name = "steel-gen"
-version = "0.3.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deabc06d4f4735677503f593ae185d3f47c0fa8089b7e9a7177e0e0544483d86"
+checksum = "e1a614449ed6cba4138ce2e54943fb403533248da8070dad6ce943f1b14417b8"
 dependencies = [
  "codegen",
  "serde",
@@ -1752,19 +1820,33 @@ dependencies = [
 
 [[package]]
 name = "steel-parser"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf95d03e34e5d34a318a1f3ad7c933628c476776d3dc4fe9accb5b7b6b5a295"
+checksum = "769cea4a36ee603bfde799ab9c1ec1f93a67df30bcf4cd22d069eb8d4155e2b2"
 dependencies = [
  "compact_str",
- "fxhash",
+ "dashmap",
  "lasso",
+ "log",
  "num-bigint",
  "num-rational",
  "num-traits",
  "once_cell",
+ "ordered-float 5.3.0",
  "pretty",
+ "rustc-hash",
  "serde",
+ "smallvec",
+ "thin-vec",
+]
+
+[[package]]
+name = "steel-quickscope"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3b5ab5dbc71b317360a2f5287abc1c91a92ced9a983066e2622a607583bc89e"
+dependencies = [
+ "indexmap 2.14.0",
  "smallvec",
 ]
 
@@ -1797,13 +1879,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "syntect"
-version = "5.2.0"
+name = "synstructure"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
 dependencies = [
  "bincode",
- "bitflags 1.3.2",
  "flate2",
  "fnv",
  "once_cell",
@@ -1813,7 +1905,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "yaml-rust",
 ]
@@ -1841,12 +1933,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "termini"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad441d87dd98bc5eeb31cf2fb7e4839968763006b478efb38668a3bf9da0d59"
+dependencies = [
+ "home",
+]
+
+[[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1854,6 +1973,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1902,10 +2032,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.50.0"
+name = "tinystr"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "serde_core",
+ "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -1920,14 +2061,53 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tstr"
@@ -1943,6 +2123,17 @@ name = "tstr_proc_macros"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78122066b0cb818b8afd08f7ed22f7fdbc3e90815035726f0840d0d26c0747a"
+
+[[package]]
+name = "two-face"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b285c51f8a6ade109ed4566d33ac4fb289fb5d6cf87ed70908a5eaf65e948e34"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "syntect",
+]
 
 [[package]]
 name = "typed-arena"
@@ -1969,12 +2160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1991,6 +2176,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "version_check"
@@ -2089,14 +2280,11 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "which"
-version = "7.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
- "either",
- "env_home",
- "rustix",
- "winsafe",
+ "libc",
 ]
 
 [[package]]
@@ -2193,15 +2381,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2361,16 +2540,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "winsafe"
-version = "0.0.19"
+name = "winnow"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xdg"
@@ -2388,6 +2573,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,6 +2609,62 @@ name = "zerocopy-derive"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "serde",
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ steel-core = { version = "0.8.0", features = ["dylibs", "sync"] }
 steel-derive = { version = "0.8.2" }
 unicode-width = "0.2.2"
 anyhow = "1.0.103"
+tokio = { version = "1.52", features = ["full"] }
 
 [dev-dependencies]
 tempfile = "3.27"
-tokio = { version = "1.50", features = ["full"] }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ ignore = "0.4.25"
 log = "0.4.30"
 scooter-core = { version = "0.3.3", features = ["steel"] }
 simple-log = "2.4.0"
-steel-core = { version = "0.8.0", features = ["dylibs", "sync"] }
+steel-core = { version = "0.8.2", features = ["dylibs", "sync"] }
 steel-derive = { version = "0.8.2" }
 unicode-width = "0.2.2"
 anyhow = "1.0.103"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ crate-type = ["cdylib"]
 abi_stable = "0.11.1"
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 etcetera = "0.11.0"
-frep-core = "0.1.3"
 ignore = "0.4.25"
 log = "0.4.30"
-scooter-core = { version = "0.1.6", features = ["steel"] }
+scooter-core = { version = "0.3.3", features = ["steel"] }
 simple-log = "2.4.0"
-steel-core = { version = "0.7.0", features = ["dylibs", "sync"] }
+steel-core = { version = "0.8.0", features = ["dylibs", "sync"] }
 steel-derive = { version = "0.8.2" }
 unicode-width = "0.2.2"
+anyhow = "1.0.103"
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/src/scooter_hx.rs
+++ b/src/scooter_hx.rs
@@ -1,19 +1,25 @@
-use frep_core::replace::{ReplaceResult, add_replacement};
-use frep_core::search::{FileSearcher, SearchResultWithReplacement};
+use scooter_core::replace::{ReplaceResult, add_replacement};
+use scooter_core::file_content::{FileContentProvider, default_file_content_provider};
+// use scooter_core::diff::DiffColour;
+use std::string::String;
+use scooter_core::search::{FileSearcher, ParsedDirConfig, ParsedSearchConfig, SearchResultWithReplacement};
 use ignore::WalkState;
 use steel::rvals::Custom;
+// use steel::rvals::TypeKind::String;
 use steel::steel_vm::ffi::FFIValue;
 use steel_derive::Steel;
+
+use anyhow::Result;
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 
-use frep_core::validation::{self, SearchConfiguration, ValidationResult};
+use scooter_core::validation::{self, DirConfig, SearchConfig, SimpleErrorHandler, ValidationResult, parse_search_text};
 use scooter_core::{
-    diff::{Diff, line_diff},
-    utils::{read_lines_range, relative_path_from, split_indexed_lines, strip_control_chars},
+    diff::{Diff, line_diff, DiffColour},
+    utils::{read_lines_range, relative_path, split_indexed_lines, strip_control_chars},
 };
 
 use crate::logging;
@@ -141,7 +147,7 @@ impl SteelSearchResult {
             .map_err(|e| format!("file read error: {e}"))?
             .collect::<Vec<_>>();
 
-        let (before, cur, after) = split_indexed_lines(lines, line_idx, screen_height - 1)
+        let (before, cur, after) = split_indexed_lines(lines, line_idx, (screen_height - 1).try_into().unwrap())
             .map_err(|e| format!("line split error: {e}"))?;
         if cur.1 != self.line {
             return Err("File content has changed".into());
@@ -164,7 +170,7 @@ impl SteelSearchResult {
 
     fn from_search_result(search_result: &SearchResultWithReplacement, directory: &Path) -> Self {
         Self {
-            display_path: relative_path_from(directory, &search_result.search_result.path),
+            display_path: relative_path(directory, &search_result.search_result.path),
             full_path: search_result
                 .search_result
                 .path
@@ -196,11 +202,11 @@ fn diffs_to_vec(diffs: &[Diff]) -> LineWithStyle {
         .iter()
         .map(|d| {
             vec![
-                strip_control_chars(&d.text),
-                d.fg_colour.to_str().to_owned(),
+                strip_control_chars(&d.text).into_owned(),
+                d.fg_colour.to_string().into(),
                 d.bg_colour
                     .clone()
-                    .map(|c| c.to_str().to_owned())
+                    .map(|c| c.to_string().into())
                     .unwrap_or_default(),
             ]
         })
@@ -243,26 +249,36 @@ impl ScooterHx {
         match_case: bool,
         include_globs: &str,
         exclude_globs: &str,
-    ) -> FFIValue {
+    ) -> Result<FFIValue, anyhow::Error> {
         self.cancel_search();
 
         *self.state.lock().unwrap() = State::NotStarted;
 
-        let search_config = SearchConfiguration {
+        let search_config = SearchConfig {
             search_text,
             replacement_text,
             fixed_strings,
             advanced_regex: false,
-            include_globs: Some(include_globs),
-            exclude_globs: Some(exclude_globs),
             match_whole_word,
             match_case,
-            include_hidden: false,
-            directory: self.directory.clone(),
+            multiline: true,
+            interpret_escape_sequences: true,
+        };
+        let parsed_search_config = ParsedSearchConfig  {
+             search: parse_search_text(&search_config)?,
+             replace: replacement_text.to_string(),
+             multiline: true,
         };
         // TODO: handle errors in UI
-        let mut error_handler = ErrorHandler::new();
-        let result = validation::validate_search_configuration(search_config, &mut error_handler);
+        let mut error_handler = SimpleErrorHandler::new();
+        let dir_config = Some(DirConfig {
+            include_globs: Some(include_globs),
+            exclude_globs: Some(exclude_globs),
+            directory: self.directory,
+            include_hidden: false,
+            include_git_folders: false,
+        });
+        let result = validation::validate_search_configuration(search_config, dir_config, &mut error_handler);
         let file_searcher = match result {
             Err(e) => {
                 return error_response(
@@ -270,12 +286,16 @@ impl ScooterHx {
                     &format!("Failed to validate search configuration: {e}"),
                 );
             }
-            Ok(ValidationResult::Success(search_config)) => FileSearcher::new(search_config),
+            Ok(ValidationResult::Success(search_config)) => {
+                FileSearcher::new(
+                    ParsedSearchConfig,
+                    ParsedDirConfig,);
+                },
+
             Ok(ValidationResult::ValidationErrors) => {
                 return validation_error_response(&error_handler);
-            }
+            },
         };
-
         let cancellation_token = Arc::new(AtomicBool::new(false));
         let state = self.state.clone();
 
@@ -415,10 +435,10 @@ impl ScooterHx {
                     cancelled_clone,
                     num_replacements_completed_clone,
                     None,
+                    default_file_content_provider(),
                     move |result| {
-                        let _ = tx.send(result); // Ignore error if receiver is dropped
-                    },
-                )
+                    let _ = tx.send(result);
+                })
             }
             _ => return,
         };
@@ -433,7 +453,7 @@ impl ScooterHx {
                 replacement_results.push(res);
             }
 
-            let stats = frep_core::replace::calculate_statistics(replacement_results);
+            let stats = scooter_core::replace::calculate_statistics(replacement_results);
 
             let mut state = state_clone.lock().unwrap();
             if let State::PerformingReplacement { .. } =
@@ -507,7 +527,7 @@ impl ScooterHx {
 mod tests {
     use std::time::Duration;
 
-    use frep_core::{line_reader::LineEnding, search::SearchResult};
+    use scooter_core::{line_reader::LineEnding, search::SearchResult};
 
     use super::*;
     use crate::test_utils::wait_until;

--- a/src/scooter_hx.rs
+++ b/src/scooter_hx.rs
@@ -109,8 +109,8 @@ impl SteelSearchResult {
             MatchContent::ByteRange{
                  lines, .. } => lines
                 .first()
-                .expect("ByteRange should contain at least one line")
-                .0,
+                .map(|(line_number, _)| *line_number)
+                .unwrap_or_default(),
         }
     }
 
@@ -158,6 +158,10 @@ impl SteelSearchResult {
                 let end = line_idx + screen_height;
 
                 let file_path = Path::new(&self.full_path);
+                let context_lines = screen_height
+                    .saturating_sub(1)
+                    .try_into()
+                    .map_err(|_| "Screen height is too large".to_string())?;
                 let lines = read_lines_range(file_path, start, end)
                     .map_err(|e| format!("file read error: {e}"))?
                     .collect::<Vec<_>>();
@@ -165,7 +169,7 @@ impl SteelSearchResult {
                 let (before, cur, after) = split_indexed_lines(
                     lines,
                     line_idx,
-                    (screen_height - 1).try_into().unwrap(),
+                    context_lines,
                 )
                 .map_err(|e| format!("line split error: {e}"))?;
 
@@ -191,6 +195,7 @@ impl SteelSearchResult {
 
             MatchContent::ByteRange {
                 lines: matched_lines,
+                content,
                 ..
             } => {
                 let (line_number, line) = matched_lines
@@ -202,6 +207,10 @@ impl SteelSearchResult {
                 let end = line_idx + screen_height;
 
                 let file_path = Path::new(&self.full_path);
+                let context_lines = screen_height
+                    .saturating_sub(1)
+                    .try_into()
+                    .map_err(|_| "Screen height is too large".to_string())?;
                 let lines = read_lines_range(file_path, start, end)
                     .map_err(|e| format!("file read error: {e}"))?
                     .collect::<Vec<_>>();
@@ -209,7 +218,7 @@ impl SteelSearchResult {
                 let (before, cur, after) = split_indexed_lines(
                     lines,
                     line_idx,
-                    (screen_height - 1).try_into().unwrap(),
+                    context_lines,
                 )
                 .map_err(|e| format!("line split error: {e}"))?;
 
@@ -219,7 +228,7 @@ impl SteelSearchResult {
                 }
 
                 let (before_segments, after_segments) =
-                    line_diff(&line.content, &self.replacement);
+                    line_diff(content, &self.replacement);
 
                 let preview_lines = before
                     .iter()
@@ -368,19 +377,7 @@ impl ScooterHx {
             multiline: true,
             interpret_escape_sequences: true,
         };
-        let parsed_search_config = ParsedSearchConfig {
-            search: match parse_search_text(&search_config) {
-                Ok(search) => search,
-                Err(e) => {
-                    return error_response(
-                        "validation-error",
-                        &format!("Failed to parse search text: {e}"),
-                    );
-                }
-            },
-            replace: replacement_text.to_string(),
-            multiline: true,
-        };        // TODO: handle errors in UI
+        // TODO: handle errors in UI
         let mut error_handler = ErrorHandler::new();
         let dir_config = Some(DirConfig {
             include_globs: Some(include_globs),

--- a/src/scooter_hx.rs
+++ b/src/scooter_hx.rs
@@ -222,13 +222,22 @@ fn diffs_to_vec(diffs: &[Diff]) -> LineWithStyle {
     diffs
         .iter()
         .map(|d| {
+            let fg = match d.fg_colour {
+                DiffColour::Red => "red",
+                DiffColour::Green => "green",
+                DiffColour::Black => "black",
+            };
+
+            let bg = d.bg_colour.as_ref().map(|c| match c {
+                DiffColour::Red => "red",
+                DiffColour::Green => "green",
+                DiffColour::Black => "black",
+            });
+
             vec![
                 strip_control_chars(&d.text).into_owned(),
-                d.fg_colour.to_string().into(),
-                d.bg_colour
-                    .clone()
-                    .map(|c| c.to_string().into())
-                    .unwrap_or_default(),
+                fg.to_owned(),
+                bg.unwrap_or("").to_owned(),
             ]
         })
         .collect()

--- a/src/scooter_hx.rs
+++ b/src/scooter_hx.rs
@@ -1,15 +1,16 @@
 use scooter_core::replace::{ReplaceResult, add_replacement};
 use scooter_core::file_content::{FileContentProvider, default_file_content_provider};
+use tokio::sync::broadcast::error;
 // use scooter_core::diff::DiffColour;
 use std::string::String;
-use scooter_core::search::{FileSearcher, ParsedDirConfig, ParsedSearchConfig, SearchResultWithReplacement};
+use scooter_core::search::{FileSearcher, ParsedDirConfig, ParsedSearchConfig, SearchResultWithReplacement, MatchContent};
 use ignore::WalkState;
 use steel::rvals::Custom;
 // use steel::rvals::TypeKind::String;
 use steel::steel_vm::ffi::FFIValue;
 use steel_derive::Steel;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -169,15 +170,35 @@ impl SteelSearchResult {
     }
 
     fn from_search_result(search_result: &SearchResultWithReplacement, directory: &Path) -> Self {
+        let (line_num, line) = match &search_result.search_result.content {
+            MatchContent::Line {
+                line_number,
+                content,
+                ..
+            } => (*line_number, content.clone()),
+            MatchContent::ByteRange { .. } => {
+                panic!("ByteRange search results are not supported");
+            }
+        };
+
         Self {
-            display_path: relative_path(directory, &search_result.search_result.path),
+            display_path: relative_path(
+                directory,
+                search_result
+                    .search_result
+                    .path
+                    .as_deref()
+                    .expect("Search result should have a path"),
+            ),
             full_path: search_result
                 .search_result
                 .path
+                .as_ref()
+                .expect("Search result should have a path")
                 .to_string_lossy()
-                .into_owned(),
-            line_num: search_result.search_result.line_number,
-            line: search_result.search_result.line.clone(),
+                .to_string(),
+            line_num,
+            line,
             replacement: search_result.replacement.clone(),
             replace_result: search_result.replace_result.clone(),
             included: search_result.search_result.included,
@@ -239,6 +260,22 @@ impl ScooterHx {
         }
     }
 
+    pub(crate) fn cancel_replacement(&mut self) {
+        let mut state = self.state.lock().unwrap();
+        if let State::PerformingReplacement { cancelled, .. } = &*state {
+            cancelled.store(true, Ordering::Relaxed);
+            *state = State::NotStarted;
+        }
+    }
+
+    pub(crate) fn replacement_errors(&self) -> Vec<SteelSearchResult> {
+        let state = self.state.lock().unwrap();
+        match &*state {
+            State::ReplacementComplete(stats) => stats.errors.clone(),
+            _ => vec![],
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn start_search(
         &mut self,
@@ -249,7 +286,7 @@ impl ScooterHx {
         match_case: bool,
         include_globs: &str,
         exclude_globs: &str,
-    ) -> Result<FFIValue, anyhow::Error> {
+    ) -> FFIValue {
         self.cancel_search();
 
         *self.state.lock().unwrap() = State::NotStarted;
@@ -264,36 +301,43 @@ impl ScooterHx {
             multiline: true,
             interpret_escape_sequences: true,
         };
-        let parsed_search_config = ParsedSearchConfig  {
-             search: parse_search_text(&search_config)?,
-             replace: replacement_text.to_string(),
-             multiline: true,
-        };
-        // TODO: handle errors in UI
-        let mut error_handler = SimpleErrorHandler::new();
+        let parsed_search_config = ParsedSearchConfig {
+            search: match parse_search_text(&search_config) {
+                Ok(search) => search,
+                Err(e) => {
+                    return error_response(
+                        "validation-error",
+                        &format!("Failed to parse search text: {e}"),
+                    );
+                }
+            },
+            replace: replacement_text.to_string(),
+            multiline: true,
+        };        // TODO: handle errors in UI
+        let mut error_handler = ErrorHandler::new();
         let dir_config = Some(DirConfig {
             include_globs: Some(include_globs),
             exclude_globs: Some(exclude_globs),
-            directory: self.directory,
+            directory: self.directory.clone(),
             include_hidden: false,
             include_git_folders: false,
         });
         let result = validation::validate_search_configuration(search_config, dir_config, &mut error_handler);
         let file_searcher = match result {
-            Err(e) => {
+             Err(e) => {
                 return error_response(
-                    "configuration-error",
+                    "validation-error",
                     &format!("Failed to validate search configuration: {e}"),
                 );
             }
-            Ok(ValidationResult::Success(search_config)) => {
+            Ok(ValidationResult::Success((parsed_search_config, parsed_dir_config))) => {
                 FileSearcher::new(
-                    ParsedSearchConfig,
-                    ParsedDirConfig,);
-                },
+                    parsed_search_config,
+                    parsed_dir_config.expect("directory config should be present"),
+                )},
 
             Ok(ValidationResult::ValidationErrors) => {
-                return validation_error_response(&error_handler);
+                return validation_error_response(&error_handler)
             },
         };
         let cancellation_token = Arc::new(AtomicBool::new(false));
@@ -505,22 +549,6 @@ impl ScooterHx {
             ),
         }
     }
-
-    pub(crate) fn cancel_replacement(&mut self) {
-        let mut state = self.state.lock().unwrap();
-        if let State::PerformingReplacement { cancelled, .. } = &*state {
-            cancelled.store(true, Ordering::Relaxed);
-            *state = State::NotStarted;
-        }
-    }
-
-    pub(crate) fn replacement_errors(&self) -> Vec<SteelSearchResult> {
-        let state = self.state.lock().unwrap();
-        match &*state {
-            State::ReplacementComplete(stats) => stats.errors.clone(),
-            _ => vec![],
-        }
-    }
 }
 
 #[cfg(test)]
@@ -566,57 +594,70 @@ mod tests {
         };
 
         let expected = vec![
-            SearchResultWithReplacement {
-                search_result: SearchResult {
-                    path: temp_dir.path().to_path_buf().join("file1.txt"),
+        SearchResultWithReplacement {
+            search_result: SearchResult {
+                path: Some(temp_dir.path().join("file1.txt")),
+                content: MatchContent::Line {
                     line_number: 2,
-                    line: "It contains TEST_PATTERN that should be replaced.".to_owned(),
+                    content: "It contains TEST_PATTERN that should be replaced.".to_owned(),
                     line_ending: LineEnding::Lf,
-                    included: true,
                 },
-                replacement: "It contains REPLACEMENT that should be replaced.".to_owned(),
-                replace_result: None,
+                included: true,
             },
-            SearchResultWithReplacement {
-                search_result: SearchResult {
-                    path: temp_dir.path().to_path_buf().join("file1.txt"),
+            replacement: "It contains REPLACEMENT that should be replaced.".to_owned(),
+            replace_result: None,
+            preview_error: None,
+        },
+        SearchResultWithReplacement {
+            search_result: SearchResult {
+                path: Some(temp_dir.path().join("file1.txt")),
+                content: MatchContent::Line {
                     line_number: 3,
-                    line: "Multiple lines with TEST_PATTERN here.".to_owned(),
+                    content: "Multiple lines with TEST_PATTERN here.".to_owned(),
                     line_ending: LineEnding::Lf,
-                    included: true,
                 },
-                replacement: "Multiple lines with REPLACEMENT here.".to_owned(),
-                replace_result: None,
+                included: true,
             },
-            SearchResultWithReplacement {
-                search_result: SearchResult {
-                    path: temp_dir.path().to_path_buf().join("file2.txt"),
+            replacement: "Multiple lines with REPLACEMENT here.".to_owned(),
+            replace_result: None,
+            preview_error: None,
+        },
+        SearchResultWithReplacement {
+            search_result: SearchResult {
+                path: Some(temp_dir.path().join("file2.txt")),
+                content: MatchContent::Line {
                     line_number: 1,
-                    line: "Another file with TEST_PATTERN.".to_owned(),
+                    content: "Another file with TEST_PATTERN.".to_owned(),
                     line_ending: LineEnding::Lf,
-                    included: true,
                 },
-                replacement: "Another file with REPLACEMENT.".to_owned(),
-                replace_result: None,
+                included: true,
             },
-            SearchResultWithReplacement {
-                search_result: SearchResult {
-                    path: temp_dir
-                        .path()
-                        .to_path_buf()
-                        .join("subdir")
-                        .join("file3.txt"),
+            replacement: "Another file with REPLACEMENT.".to_owned(),
+            replace_result: None,
+            preview_error: None,
+        },
+        SearchResultWithReplacement {
+            search_result: SearchResult {
+                path: Some(temp_dir.path().join("subdir").join("file3.txt")),
+                content: MatchContent::Line {
                     line_number: 1,
-                    line: "Nested file with TEST_PATTERN.".to_owned(),
+                    content: "Nested file with TEST_PATTERN.".to_owned(),
                     line_ending: LineEnding::Lf,
-                    included: true,
                 },
-                replacement: "Nested file with REPLACEMENT.".to_owned(),
-                replace_result: None,
+                included: true,
             },
-        ];
-        search_results_clone
-            .sort_by_key(|s| (s.search_result.path.clone(), s.search_result.line_number));
+            replacement: "Nested file with REPLACEMENT.".to_owned(),
+            replace_result: None,
+            preview_error: None,
+        },
+    ];
+        search_results_clone.sort_by_key(|s| {
+            let line = match &s.search_result.content {
+                MatchContent::Line { line_number, .. } => *line_number,
+                MatchContent::ByteRange { .. } => 0,
+            };
+            (s.search_result.path.clone(), line)
+        });
         assert_eq!(search_results_clone, expected);
 
         scooter.start_replace();

--- a/src/scooter_hx.rs
+++ b/src/scooter_hx.rs
@@ -81,14 +81,13 @@ pub(crate) struct ScooterHx {
 impl Custom for ScooterHx {}
 
 #[derive(Clone, Debug, Eq, Steel, PartialEq)]
-pub(crate) struct SteelSearchResult {
-    pub(crate) display_path: String,
-    pub(crate) full_path: String,
-    pub(crate) line_num: usize,
-    pub(crate) line: String,
-    pub(crate) replacement: String,
-    pub(crate) replace_result: Option<ReplaceResult>,
-    pub(crate) included: bool,
+pub struct SteelSearchResult {
+    display_path: String,
+    full_path: String,
+    match_content: MatchContent,
+    replacement: String,
+    replace_result: Option<ReplaceResult>,
+    included: bool,
 }
 
 impl SteelSearchResult {
@@ -101,7 +100,14 @@ impl SteelSearchResult {
     }
 
     pub(crate) fn line_num(&self) -> usize {
-        self.line_num
+        match &self.match_content {
+            MatchContent::Line { line_number, .. } => *line_number,
+            MatchContent::ByteRange{
+                 lines, .. } => lines
+                .first()
+                .expect("ByteRange should contain at least one line")
+                .0,
+        }
     }
 
     pub(crate) fn build_preview(&self, screen_height: usize) -> Vec<LineWithStyle> {
@@ -137,48 +143,99 @@ impl SteelSearchResult {
     }
 
     fn try_build_preview(&self, screen_height: usize) -> Result<Vec<LineWithStyle>, String> {
-        let line_idx = self.line_num.saturating_sub(1); // Convert to 0-based index
-        let start = line_idx.saturating_sub(screen_height);
-        let end = line_idx + screen_height;
-
-        let file_path = Path::new(&self.full_path);
-        let lines = read_lines_range(file_path, start, end)
-            .map_err(|e| format!("file read error: {e}"))?
-            .collect::<Vec<_>>();
-
-        let (before, cur, after) = split_indexed_lines(lines, line_idx, (screen_height - 1).try_into().unwrap())
-            .map_err(|e| format!("line split error: {e}"))?;
-        if cur.1 != self.line {
-            return Err("File content has changed".into());
-        }
-
-        let (before_segments, after_segments) = line_diff(&self.line, &self.replacement);
-
-        let preview_lines = before
-            .iter()
-            .map(|(_, l)| str_to_vec(l))
-            .chain(vec![
-                diffs_to_vec(&before_segments),
-                diffs_to_vec(&after_segments),
-            ])
-            .chain(after.iter().map(|(_, l)| str_to_vec(l)))
-            .collect();
-
-        Ok(preview_lines)
-    }
-
-    fn from_search_result(search_result: &SearchResultWithReplacement, directory: &Path) -> Self {
-        let (line_num, line) = match &search_result.search_result.content {
+        match &self.match_content {
             MatchContent::Line {
                 line_number,
                 content,
                 ..
-            } => (*line_number, content.clone()),
-            MatchContent::ByteRange { .. } => {
-                panic!("ByteRange search results are not supported");
-            }
-        };
+            } => {
+                let line_idx = line_number.saturating_sub(1);
+                let start = line_idx.saturating_sub(screen_height);
+                let end = line_idx + screen_height;
 
+                let file_path = Path::new(&self.full_path);
+                let lines = read_lines_range(file_path, start, end)
+                    .map_err(|e| format!("file read error: {e}"))?
+                    .collect::<Vec<_>>();
+
+                let (before, cur, after) = split_indexed_lines(
+                    lines,
+                    line_idx,
+                    (screen_height - 1).try_into().unwrap(),
+                )
+                .map_err(|e| format!("line split error: {e}"))?;
+
+                if cur.1 != *content {
+                    return Err("File content has changed".into());
+                }
+
+                let (before_segments, after_segments) =
+                    line_diff(content, &self.replacement);
+
+                let preview_lines = before
+                    .iter()
+                    .map(|(_, l)| str_to_vec(l))
+                    .chain(vec![
+                        diffs_to_vec(&before_segments),
+                        diffs_to_vec(&after_segments),
+                    ])
+                    .chain(after.iter().map(|(_, l)| str_to_vec(l)))
+                    .collect();
+
+                Ok(preview_lines)
+            }
+
+            MatchContent::ByteRange {
+                lines: matched_lines,
+                ..
+            } => {
+                let (line_number, line) = matched_lines
+                    .first()
+                    .ok_or_else(|| "ByteRange contained no lines".to_string())?;
+
+                let line_idx = line_number.saturating_sub(1);
+                let start = line_idx.saturating_sub(screen_height);
+                let end = line_idx + screen_height;
+
+                let file_path = Path::new(&self.full_path);
+                let lines = read_lines_range(file_path, start, end)
+                    .map_err(|e| format!("file read error: {e}"))?
+                    .collect::<Vec<_>>();
+
+                let (before, cur, after) = split_indexed_lines(
+                    lines,
+                    line_idx,
+                    (screen_height - 1).try_into().unwrap(),
+                )
+                .map_err(|e| format!("line split error: {e}"))?;
+
+                // Adjust this field access depending on the definition of `Line`.
+                if cur.1 != line.content {
+                    return Err("File content has changed".into());
+                }
+
+                let (before_segments, after_segments) =
+                    line_diff(&line.content, &self.replacement);
+
+                let preview_lines = before
+                    .iter()
+                    .map(|(_, l)| str_to_vec(l))
+                    .chain(vec![
+                        diffs_to_vec(&before_segments),
+                        diffs_to_vec(&after_segments),
+                    ])
+                    .chain(after.iter().map(|(_, l)| str_to_vec(l)))
+                    .collect();
+
+                Ok(preview_lines)
+            }
+        }
+    }
+
+    fn from_search_result(
+        search_result: &SearchResultWithReplacement,
+        directory: &Path,
+    ) -> Self {
         Self {
             display_path: relative_path(
                 directory,
@@ -195,8 +252,7 @@ impl SteelSearchResult {
                 .expect("Search result should have a path")
                 .to_string_lossy()
                 .to_string(),
-            line_num,
-            line,
+            match_content: search_result.search_result.content.clone(),
             replacement: search_result.replacement.clone(),
             replace_result: search_result.replace_result.clone(),
             included: search_result.search_result.included,

--- a/src/scooter_hx.rs
+++ b/src/scooter_hx.rs
@@ -1,23 +1,21 @@
 use scooter_core::replace::{ReplaceResult, add_replacement};
-use scooter_core::file_content::{FileContentProvider, default_file_content_provider};
-use tokio::sync::broadcast::error;
-// use scooter_core::diff::DiffColour;
+use scooter_core::file_content::{default_file_content_provider};
 use std::string::String;
-use scooter_core::search::{FileSearcher, ParsedDirConfig, ParsedSearchConfig, SearchResultWithReplacement, MatchContent};
+use scooter_core::search::{FileSearcher, ParsedSearchConfig, SearchResultWithReplacement, MatchContent};
 use ignore::WalkState;
 use steel::rvals::Custom;
 // use steel::rvals::TypeKind::String;
 use steel::steel_vm::ffi::FFIValue;
 use steel_derive::Steel;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Result};
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 
-use scooter_core::validation::{self, DirConfig, SearchConfig, SimpleErrorHandler, ValidationResult, parse_search_text};
+use scooter_core::validation::{self, DirConfig, SearchConfig, ValidationResult, parse_search_text};
 use scooter_core::{
     diff::{Diff, line_diff, DiffColour},
     utils::{read_lines_range, relative_path, split_indexed_lines, strip_control_chars},

--- a/src/scooter_hx.rs
+++ b/src/scooter_hx.rs
@@ -137,7 +137,7 @@ impl SteelSearchResult {
             }
         };
 
-        let path_display = format!("{}:{}", self.display_path, self.line_num);
+        let path_display = format!("{}:{}", self.display_path, self.line_num());
 
         vec![path_display, error.clone()]
     }

--- a/src/scooter_hx.rs
+++ b/src/scooter_hx.rs
@@ -1,4 +1,8 @@
 use scooter_core::replace::{ReplaceResult, add_replacement};
+use scooter_core::{
+    line_reader::LineEnding,
+    search::{Line, SearchResult},
+};
 use scooter_core::file_content::{default_file_content_provider};
 use std::string::String;
 use scooter_core::search::{FileSearcher, ParsedSearchConfig, SearchResultWithReplacement, MatchContent};
@@ -657,63 +661,99 @@ mod tests {
         };
 
         let expected = vec![
-        SearchResultWithReplacement {
-            search_result: SearchResult {
-                path: Some(temp_dir.path().join("file1.txt")),
-                content: MatchContent::Line {
-                    line_number: 2,
-                    content: "It contains TEST_PATTERN that should be replaced.".to_owned(),
-                    line_ending: LineEnding::Lf,
+            SearchResultWithReplacement {
+                search_result: SearchResult {
+                    path: Some(temp_dir.path().join("file1.txt")),
+                    content: MatchContent::ByteRange {
+                        lines: vec![(
+                            2,
+                            Line {
+                                content: "It contains TEST_PATTERN that should be replaced.".to_owned(),
+                                line_ending: LineEnding::Lf,
+                            },
+                        )],
+                        match_start_in_first_line: 12,
+                        match_end_in_last_line: 24,
+                        byte_start: 33,
+                        byte_end: 45,
+                        content: "TEST_PATTERN".to_owned(),
+                    },
+                    included: true,
                 },
-                included: true,
+                replacement: "REPLACEMENT".to_owned(),
+                replace_result: None,
+                preview_error: None,
             },
-            replacement: "It contains REPLACEMENT that should be replaced.".to_owned(),
-            replace_result: None,
-            preview_error: None,
-        },
-        SearchResultWithReplacement {
-            search_result: SearchResult {
-                path: Some(temp_dir.path().join("file1.txt")),
-                content: MatchContent::Line {
-                    line_number: 3,
-                    content: "Multiple lines with TEST_PATTERN here.".to_owned(),
-                    line_ending: LineEnding::Lf,
+            SearchResultWithReplacement {
+                search_result: SearchResult {
+                    path: Some(temp_dir.path().join("file1.txt")),
+                    content: MatchContent::ByteRange {
+                        lines: vec![(
+                            3,
+                            Line {
+                                content: "Multiple lines with TEST_PATTERN here.".to_owned(),
+                                line_ending: LineEnding::Lf,
+                            },
+                        )],
+                        match_start_in_first_line: 20,
+                        match_end_in_last_line: 32,
+                        byte_start: 91,
+                        byte_end: 103,
+                        content: "TEST_PATTERN".to_owned(),
+                    },
+                    included: true,
                 },
-                included: true,
+                replacement: "REPLACEMENT".to_owned(),
+                replace_result: None,
+                preview_error: None,
             },
-            replacement: "Multiple lines with REPLACEMENT here.".to_owned(),
-            replace_result: None,
-            preview_error: None,
-        },
-        SearchResultWithReplacement {
-            search_result: SearchResult {
-                path: Some(temp_dir.path().join("file2.txt")),
-                content: MatchContent::Line {
-                    line_number: 1,
-                    content: "Another file with TEST_PATTERN.".to_owned(),
-                    line_ending: LineEnding::Lf,
+            SearchResultWithReplacement {
+                search_result: SearchResult {
+                    path: Some(temp_dir.path().join("file2.txt")),
+                    content: MatchContent::ByteRange {
+                        lines: vec![(
+                            1,
+                            Line {
+                                content: "Another file with TEST_PATTERN.".to_owned(),
+                                line_ending: LineEnding::Lf,
+                            },
+                        )],
+                        match_start_in_first_line: 18,
+                        match_end_in_last_line: 30,
+                        byte_start: 18,
+                        byte_end: 30,
+                        content: "TEST_PATTERN".to_owned(),
+                    },
+                    included: true,
                 },
-                included: true,
+                replacement: "REPLACEMENT".to_owned(),
+                replace_result: None,
+                preview_error: None,
             },
-            replacement: "Another file with REPLACEMENT.".to_owned(),
-            replace_result: None,
-            preview_error: None,
-        },
-        SearchResultWithReplacement {
-            search_result: SearchResult {
-                path: Some(temp_dir.path().join("subdir").join("file3.txt")),
-                content: MatchContent::Line {
-                    line_number: 1,
-                    content: "Nested file with TEST_PATTERN.".to_owned(),
-                    line_ending: LineEnding::Lf,
+            SearchResultWithReplacement {
+                search_result: SearchResult {
+                    path: Some(temp_dir.path().join("subdir").join("file3.txt")),
+                    content: MatchContent::ByteRange {
+                        lines: vec![(
+                            1,
+                            Line {
+                                content: "Nested file with TEST_PATTERN.".to_owned(),
+                                line_ending: LineEnding::Lf,
+                            },
+                        )],
+                        match_start_in_first_line: 17,
+                        match_end_in_last_line: 29,
+                        byte_start: 17,
+                        byte_end: 29,
+                        content: "TEST_PATTERN".to_owned(),
+                    },
+                    included: true,
                 },
-                included: true,
+                replacement: "REPLACEMENT".to_owned(),
+                replace_result: None,
+                preview_error: None,
             },
-            replacement: "Nested file with REPLACEMENT.".to_owned(),
-            replace_result: None,
-            preview_error: None,
-        },
-    ];
+        ];
         search_results_clone.sort_by_key(|s| {
             let line = match &s.search_result.content {
                 MatchContent::Line { line_number, .. } => *line_number,

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,5 +1,5 @@
 use abi_stable::std_types::RHashMap;
-use frep_core::validation::ValidationErrorHandler;
+use scooter_core::validation::ValidationErrorHandler;
 use steel::steel_vm::ffi::FFIValue;
 
 #[derive(Clone, Default, Eq, PartialEq)]


### PR DESCRIPTION
## Summary

Update `scooter.hx` to the latest `scooter-core` API and remove the remaining `frep-core` dependency.

This updates the search and replacement integration to use the current `scooter-core` types and APIs while preventing crashes when `ByteRange` search results are returned.

## Changes

* Migrate from `frep-core` to `scooter-core` throughout the project.
* Update to the latest `scooter-core` search and validation APIs.
* Store `MatchContent` directly in `SteelSearchResult` instead of flattening search results into line-based fields.
* Handle both `MatchContent::Line` and `MatchContent::ByteRange` when displaying search results and building previews.
* Update tests to reflect the new `SearchResult` and replacement APIs.

## Why?

Recent versions of `scooter-core` changed the search result model from line-based results to `MatchContent`, which can represent either traditional single-line matches (`Line`) or precise byte-range matches (`ByteRange`).

Previously, `scooter.hx` assumed every result was line-based and would panic when encountering a `ByteRange`:

```rust
MatchContent::ByteRange { .. } => {
    panic!("ByteRange search results are not supported");
}
```

Since this code executes inside a Steel FFI plugin, the panic propagated across the FFI boundary and aborted the plugin.

By storing `MatchContent` directly instead of extracting only the line number and line contents, the plugin preserves the information returned by `scooter-core` and can handle both result types without crashing.

The preview implementation now dispatches based on the `MatchContent` variant. For `ByteRange` results it currently uses the first matched line as the preview, providing compatibility with the new API while leaving room for richer multiline previews in the future.

As part of this migration, the remaining `frep-core` dependency and related compatibility code were removed in favour of the current `scooter-core` APIs.

The tests complete and I have the plugin running on helix 25.07.1 (c85dda9b)