### PR TITLE
Fix release workflow stuck on retired macos-13 runner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,12 @@ jobs:
   prepare-release:
     name: Prepare release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       version: ${{ steps.get-package-info.outputs.version }}
-      should_release: ${{ steps.check-version.outputs.exists == 'false' }}
+      should_release: ${{ steps.check-version.outputs.state == 'create' || steps.check-version.outputs.state == 'resume' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -52,16 +53,36 @@ jobs:
         run: |
           version="${{ steps.get-package-info.outputs.version }}"
 
-          if gh release view "v${version}" &>/dev/null; then
-            echo "Release v${version} already exists" >&2
-            echo "exists=true" >> $GITHUB_OUTPUT
+          error_file=$(mktemp)
+          if draft_status=$(gh release view "v${version}" --json isDraft --jq '.isDraft' 2>"$error_file"); then
+            rm "$error_file"
+            case "$draft_status" in
+              true)
+                state=resume
+                ;;
+              false)
+                state=published
+                ;;
+              *)
+                echo "ERROR: Unexpected draft status for release v${version}: ${draft_status}" >&2
+                exit 1
+                ;;
+            esac
+          elif grep -Eqi 'release not found|HTTP 404' "$error_file"; then
+            rm "$error_file"
+            state=create
           else
-            echo "Release v${version} does not exist" >&2
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "ERROR: Failed to determine release state for v${version}" >&2
+            cat "$error_file" >&2
+            rm "$error_file"
+            exit 1
           fi
 
+          echo "Release v${version} state: ${state}"
+          echo "state=${state}" >> $GITHUB_OUTPUT
+
       - name: Create release
-        if: steps.check-version.outputs.exists == 'false'
+        if: steps.check-version.outputs.state == 'create'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -69,8 +90,12 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
-          git tag -a "v${version}" -m "Release v${version}"
-          git push origin "v${version}"
+          if git rev-parse -q --verify "refs/tags/v${version}" >/dev/null || git ls-remote --exit-code --tags origin "v${version}" >/dev/null; then
+            echo "Tag v${version} already exists; skipping tag creation"
+          else
+            git tag -a "v${version}" -m "Release v${version}"
+            git push origin "v${version}"
+          fi
 
           gh release create "v${version}" \
             --title "v${version}" \
@@ -82,6 +107,7 @@ jobs:
     if: needs.prepare-release.outputs.should_release == 'true'
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -96,7 +122,7 @@ jobs:
             use-cross: true
             cargo_output_name: libscooter_hx.so
             asset_name: libscooter_hx.aarch64-linux.so
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             use-cross: false
             cargo_output_name: libscooter_hx.dylib
@@ -113,9 +139,10 @@ jobs:
             asset_name: libscooter_hx.x86_64-windows.dll
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
+        ref: v${{ needs.prepare-release.outputs.version }}
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -151,6 +178,7 @@ jobs:
     needs: [prepare-release, build-and-upload]
     if: needs.prepare-release.outputs.should_release == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Publish release
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Problem

The v0.2.0 Release run ([30217419518](https://github.com/thomasschafer/scooter.hx/actions/runs/30217419518)) hung. The `x86_64-apple-darwin` build targets `runs-on: macos-13`, an image GitHub [retired on 2025-12-04](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/). No runner can satisfy that label, so the job sat in `queued` until it was cancelled.

This went unnoticed for months because `release.yml` only fires on pushes touching `Cargo.toml`, and the last release predated the retirement. `test.yml` only uses `macos-latest`.

Current state: tag `v0.2.0` exists, and release `v0.2.0` exists as a draft with 4 of 5 assets (missing `libscooter_hx.x86_64-macos.dylib`).

## Changes

- **`macos-13` -> `macos-15-intel`** — the current standard x86_64 macOS image, free for public repos.
- **`prepare-release` is now resumable.** The old guard treated any existing release as "already shipped", so re-dispatching after a partial failure skipped every build. It now classifies into `create` / `resume` / `published`, where a half-finished *draft* resumes instead of being skipped. This is what lets v0.2.0 be recovered without deleting the tag and release.
- **Builds check out the release tag**, not the triggering branch. These normally coincide, but diverge on a `workflow_dispatch` resume — without this, v0.2.0's Intel dylib would have been built from different source than the four artifacts already uploaded.
- **Tag creation tolerates a pre-existing tag**, covering the partial failure where a tag is pushed but release creation then fails.
- **`actions/checkout` v4 -> v5**, clearing the Node 20 deprecation warning.
- **Job timeouts** (15/60/15). This caps a runaway build; it does not bound queue time, so it would not by itself have caught this hang.
- **Dependabot now tracks `github-actions`.** Note this updates action *versions*, not `runs-on` labels, so it would not have caught the `macos-13` retirement either.

`clechasseur/rs-cargo@v2` (also Node 20) and `checkout` v5 -> v7 are deliberately left alone — jumping several majors in the release-critical build path belongs in separate reviewable Dependabot PRs, not here.

## Validation

- All three files parse as YAML.
- The `create`-path detection was tested against real `gh` output and simulated failures: `release not found` and `HTTP 404` variants classify as `create`, while auth, network, and rate-limit errors still fail loudly rather than being misread as "no release exists".
- `cog.scm` and `Cargo.toml` both read `0.2.0` at HEAD and at tag `v0.2.0`, so the version-match gate passes.
- The release path itself is only exercised by `workflow_dispatch`, which will be run against this once merged.