### PR TITLE
Group dependabot updates to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,23 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      cargo-major:
+        update-types:
+          - "major"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        update-types:
+          - "major"


### PR DESCRIPTION
## Summary
- Groups cargo and github-actions dependabot updates into minor/patch vs major groups, so routine bumps land as a single PR per ecosystem instead of one PR per dependency.

## Test plan
- [ ] Confirm dependabot picks up the new config on its next run and produces grouped PRs