### PR TITLE
Fix release workflow for rs-cargo v3+ tool input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,27 +114,27 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            use-cross: false
+            tool: ""
             cargo_output_name: libscooter_hx.so
             asset_name: libscooter_hx.x86_64-linux.so
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            use-cross: true
+            tool: cross
             cargo_output_name: libscooter_hx.so
             asset_name: libscooter_hx.aarch64-linux.so
           - os: macos-15-intel
             target: x86_64-apple-darwin
-            use-cross: false
+            tool: ""
             cargo_output_name: libscooter_hx.dylib
             asset_name: libscooter_hx.x86_64-macos.dylib
           - os: macos-latest
             target: aarch64-apple-darwin
-            use-cross: false
+            tool: ""
             cargo_output_name: libscooter_hx.dylib
             asset_name: libscooter_hx.aarch64-macos.dylib
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            use-cross: false
+            tool: ""
             cargo_output_name: scooter_hx.dll
             asset_name: libscooter_hx.x86_64-windows.dll
 
@@ -155,11 +155,11 @@ jobs:
         key: v1-${{ matrix.target }}
 
     - name: Build library
-      uses: clechasseur/rs-cargo@v2
+      uses: clechasseur/rs-cargo@v4
       with:
         command: build
         args: --release --target ${{ matrix.target }} --manifest-path Cargo.toml
-        use-cross: ${{ matrix.use-cross }}
+        tool: ${{ matrix.tool }}
 
     - name: Rename library
       shell: bash


### PR DESCRIPTION
## Summary
- rs-cargo v3.0.0 removed the `use-cross` input in favor of `tool` (must be `cross` for cross-compilation). Updates the matrix and build step accordingly, and bumps `clechasseur/rs-cargo` to v4 since `tool` doesn't exist on v2.
- Unblocks dependabot PR #61 (actions-major group), which bumps rs-cargo from v2 to v4 but doesn't touch the now-removed `use-cross` input — merging that PR without this fix would silently break the aarch64-linux cross-compiled release build.

## Test plan
- [ ] `release.yml` only runs on a push to main that touches `Cargo.toml`, or via manual `workflow_dispatch` — not exercised by this PR's CI. Verified the `tool` input semantics against rs-cargo's v4 README (`tool: cross` invokes `cross` instead of `cargo`, matching the previous `use-cross: true` behavior).
- [ ] Recommend watching the next real release run (or a deliberate `workflow_dispatch`) to confirm the aarch64-linux cross build still succeeds.